### PR TITLE
Update 'required' rule to prohibit blank spaces

### DIFF
--- a/src/simple-react-validator.js
+++ b/src/simple-react-validator.js
@@ -41,7 +41,7 @@ class SimpleReactValidator {
       numeric              : {message: 'The :attribute must be a number.',                                      rule: val => this.helpers.numeric(val)},
       phone                : {message: 'The :attribute must be a valid phone number.',                          rule: val => this.helpers.testRegex(val,/^(\+?\d{0,4})?\s?-?\s?(\(?\d{3}\)?)\s?-?\s?(\(?\d{3}\)?)\s?-?\s?(\(?\d{4}\)?)?$/)},
       regex                : {message: 'The :attribute must match the required pattern.',                       rule: (val, params) => this.helpers.testRegex(val, typeof params[0] === 'string' || params[0] instanceof String ? new RegExp(params[0]) : params[0])},
-      required             : {message: 'The :attribute field is required.',                                     rule: val => !this.helpers.isBlank(val), required: true },
+      required             : {message: 'The :attribute field is required.',                                     rule: val => this.helpers.testRegex(val, /[^\s]/), required: true },
       size                 : {message: 'The :attribute must be :size:type.',                                    rule: (val, params) => this.helpers.size(val, params[1]) == parseFloat(params[0]), messageReplace: (message, params) => message.replace(':size', params[0]).replace(':type', this.helpers.sizeText(params[1]))},
       string               : {message: 'The :attribute must be a string.',                                      rule: val => typeof(val) === typeof('string')},
       typeof               : {message: 'The :attribute is not the correct type of :type.',                      rule: (val, params) => typeof(val) === typeof(params[0]), messageReplace: (message, params) => message.replace(':type', typeof(params[0]))},


### PR DESCRIPTION
On 'required' rule, updated this:
this.helpers.isBlank(val)
to a regex that makes sure the value is NOT a blank space(tab, space, etc):
this.helpers.testRegex(val, /[^\s]/)